### PR TITLE
Make Zammad release channel configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ zammad_version: "3.3.0"
 Zammad version to be installed.
 
 ```yaml
+zammad_release_channel: "stable"
+```
+Choose another release channel for the Zammad packages.
+Please refer to https://packager.io/gh/zammad/zammad for a complete list.
+
+```yaml
 zammad_domain_name: "{{ ansible_fqdn }}"
 ```
 Zammad's fully qualified domain name.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 zammad_version: "3.3.0"
+zammad_release_channel: "stable"
 zammad_domain_name: "{{ ansible_fqdn }}"
 
 zammad_nginx_config_path: "/etc/nginx/sites-available/zammad.conf"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -12,8 +12,8 @@
       yum_repository:
         name: zammad
         state: present
-        description: Repository for zammad/zammad (stable) packages.
-        baseurl: https://dl.packager.io/srv/rpm/zammad/zammad/stable/el/7/$basearch
+        description: Repository for zammad/zammad ({{ zammad_release_channel }}) packages.
+        baseurl: https://dl.packager.io/srv/rpm/zammad/zammad/{{ zammad_release_channel }}/el/7/$basearch
         enabled: yes
         gpgcheck: no
         repo_gpgcheck: yes
@@ -29,7 +29,7 @@
 
     - name: Install | Add Zammad DEB repository
       apt_repository:
-        repo: deb https://dl.packager.io/srv/deb/zammad/zammad/stable/ubuntu {{ ansible_distribution_version }} main
+        repo: deb https://dl.packager.io/srv/deb/zammad/zammad/{{ zammad_release_channel }}/ubuntu {{ ansible_distribution_version }} main
         state: present
         filename: zammad
         update_cache: yes


### PR DESCRIPTION
This change allows to also select the `development` channel useful for test instances.

- Introduce a new variable called `zammad_release_channel`
- Set `zammad_release_channel` to `stable` by default
- Add the new variable to the README list

Closes #3 