### PR TITLE
Install Zammad 3.4.0 by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-zammad_version: "3.3.0"
+zammad_version: "3.4.0"
 zammad_release_channel: "stable"
 zammad_domain_name: "{{ ansible_fqdn }}"
 


### PR DESCRIPTION
This PR bumps the default Zammad version to 3.4.0.

Signed-off-by: Norman Ziegner <norman.ziegner@ufz.de>