### PR TITLE
Allow to optionally configure additional Nginx server directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,29 @@ zammad_ssl_key:
 Content of SSL/TLS private key (**required**).
 
 ```yaml
+zammad_nginx_additional_server_configs:
+  - |
+      server {
+        listen 80;
+        server_name zammad.example.com zammad-old.example.com;
+        return 301 https://zammad.example.com$request_uri;
+      }
+  - |
+      server {
+        listen 443 ssl;
+
+        # ... SSL configuration
+
+        server_name zammad-old.example.com;
+        return 301 https://zammad.example.com$request_uri;
+      }
+```
+Configure additional server directives in the Nginx configuration.
+This allows to implement more use case specific adjustments, e.g.
+configuring multiple domains or the redirection of outdated domains to the
+most recent one.
+
+```yaml
 elasticsearch_url: "http://localhost:9200"
 ```
 Elasticsearch server address.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,5 +10,7 @@ zammad_ssl_key_path: "/etc/ssl/private/zammad_key.pem"
 zammad_ssl_key:
 zammad_ssl_cert:
 
+zammad_nginx_additional_server_configs: []
+
 elasticsearch_url: "http://localhost:9200"
 ...

--- a/templates/nginx-zammad.conf.j2
+++ b/templates/nginx-zammad.conf.j2
@@ -64,3 +64,7 @@ server {
         gzip_proxied any;
     }
 }
+
+{% for server_config in zammad_nginx_additional_server_configs %}
+{{ server_config }}
+{% endfor %}


### PR DESCRIPTION
This implements a new configuration variable `zammad_nginx_additional_server_configs` that can optionally be used to extend the Nginx configuration with additional server directives.