### PR TITLE
Update molecule action

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -27,5 +27,4 @@ jobs:
           path: "${{ github.repository }}"
 
       - name: Molecule test
-#        uses: robertdebock/molecule-action@2.0.0
-        uses: normo/molecule-action@jmespath
+        uses: robertdebock/molecule-action@2.6.1


### PR DESCRIPTION
This PR switches back to [robertdebock/molecule-action](https://github.com/robertdebock/molecule-action/releases/tag/2.6.1).