### PR TITLE
Allow to use SSL keypair given by path only

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Content of SSL/TLS private key (**required**).
 **Please note:** In the special case, that you previously put an SSL keypair
 on the host, e.g. via Let's Encrypt, you must not configure the variables
 `zammad_ssl_cert` and `zammad_ssl_key`. Nevertheless, in each case the role will
-alidate, if the SSL key pair given under the paths `zammad_ssl_key_path` and
+validate, if the SSL key pair is given under the paths `zammad_ssl_key_path` and
 `zammad_ssl_cert_path` are valid.
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -50,7 +50,12 @@ Content of SSL/TLS certificate (**required**).
 ```yaml
 zammad_ssl_key:
 ```
-Content of SSL/TLS private key (**required**).
+Content of SSL/TLS private key (**required**).  
+**Please note:** In the special case, that you previously put an SSL keypair
+on the host, e.g. via Let's Encrypt, you must not configure the variables
+`zammad_ssl_cert` and `zammad_ssl_key`. Nevertheless, in each case the role will
+alidate, if the SSL key pair given under the paths `zammad_ssl_key_path` and
+`zammad_ssl_cert_path` are valid.
 
 ```yaml
 zammad_nginx_additional_server_configs:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,9 +7,6 @@ zammad_nginx_config_path: "/etc/nginx/sites-available/zammad.conf"
 zammad_ssl_cert_path: "/etc/ssl/certs/zammad_cert.pem"
 zammad_ssl_key_path: "/etc/ssl/private/zammad_key.pem"
 
-zammad_ssl_key:
-zammad_ssl_cert:
-
 zammad_nginx_additional_server_configs: []
 
 elasticsearch_url: "http://localhost:9200"

--- a/tasks/ssl.yml
+++ b/tasks/ssl.yml
@@ -9,6 +9,7 @@
     mode: 0640
     owner: root
     group: root
+  when: zammad_ssl_key is undefined or zammad_ssl_key|length > 0
 
 - name: SSL | Insert certificate
   blockinfile:
@@ -19,6 +20,7 @@
     mode: 0644
     owner: root
     group: root
+  when: zammad_ssl_cert is undefined or zammad_ssl_cert|length > 0
 
 - name: SSL | Check if certificate is still valid, ignoring failures
   openssl_certificate_info:

--- a/tasks/ssl.yml
+++ b/tasks/ssl.yml
@@ -9,7 +9,7 @@
     mode: 0640
     owner: root
     group: root
-  when: zammad_ssl_key is undefined or zammad_ssl_key|length > 0
+  when: zammad_ssl_key is defined or zammad_ssl_key|length > 0
 
 - name: SSL | Insert certificate
   blockinfile:
@@ -20,7 +20,7 @@
     mode: 0644
     owner: root
     group: root
-  when: zammad_ssl_cert is undefined or zammad_ssl_cert|length > 0
+  when: zammad_ssl_cert is defined or zammad_ssl_cert|length > 0
 
 - name: SSL | Check if certificate is still valid, ignoring failures
   openssl_certificate_info:


### PR DESCRIPTION
This change allows to configure SSH keypair that already exists on the
machine. E.g. it could have been created in a previous role via Let's
Encrypt. So far, the created key would have been overwritten by this
role.

Closes #13 