### PR TITLE
Allow to configure nginx server_tokens directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Content of SSL/TLS private key (**required**).
 zammad_nginx_server_tokens: "off"
 ```
 Enable or disable emitting nginx version information in error pages or in the
-_Server_ response header field. Please read the NGinx
+_Server_ response header field. Please read the nginx
 [docs](http://nginx.org/en/docs/http/ngx_http_core_module.html#server_tokens)
 for further information.
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ zammad_ssl_key:
 Content of SSL/TLS private key (**required**).
 
 ```yaml
+zammad_nginx_server_tokens: "off"
+```
+Enable or disable emitting nginx version information in error pages or in the
+_Server_ response header field. Please read the NGinx
+[docs](http://nginx.org/en/docs/http/ngx_http_core_module.html#server_tokens)
+for further information.
+
+```yaml
 zammad_nginx_additional_server_configs:
   - |
       server {

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,7 @@ zammad_ssl_key:
 zammad_ssl_cert:
 
 zammad_nginx_additional_server_configs: []
+zammad_nginx_server_tokens: "off"
 
 elasticsearch_url: "http://localhost:9200"
 ...

--- a/templates/nginx-zammad.conf.j2
+++ b/templates/nginx-zammad.conf.j2
@@ -14,6 +14,7 @@ upstream zammad-websocket {
 server {
     listen 80;
     server_name {{ zammad_domain_name }};
+    server_tokens {{ zammad_nginx_server_tokens }};
     return 301 https://{{ zammad_domain_name }}$request_uri;
 }
 
@@ -31,6 +32,8 @@ server {
 
     access_log /var/log/nginx/zammad.access.log;
     error_log  /var/log/nginx/zammad.error.log;
+
+    server_tokens {{ zammad_nginx_server_tokens }};
 
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 


### PR DESCRIPTION
Thereby, enable or disable emitting the NGinx version information in error pages or in the _Server_ response header field. This introduces a new variable called `zammad_nginx_server_tokens` which is set to `off` by default.

Closes #15 