### PR TITLE
Update molecule action

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -30,6 +30,6 @@ jobs:
           path: "${{ github.repository }}"
 
       - name: Molecule test
-        uses: robertdebock/molecule-action@2.6.1
+        uses: robertdebock/molecule-action@2.6.3
         env:
           MOLECULE_IMAGE: "${{ matrix.images }}"


### PR DESCRIPTION
Bump [robertdebock/molecule-action](https://github.com/robertdebock/molecule-action/releases) to `2.6.3`.