### PR TITLE
Add Ansible Galaxy release job

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -33,3 +33,13 @@ jobs:
         uses: robertdebock/molecule-action@2.6.3
         env:
           MOLECULE_IMAGE: "${{ matrix.images }}"
+
+  release:
+    needs: test
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: galaxy
+        uses: robertdebock/galaxy-action@1.1.0
+        with:
+          galaxy_api_key: ${{ secrets.galaxy_api_key }}


### PR DESCRIPTION
This PR adds a CI job to publish this role to [Ansible Galaxy](https://galaxy.ansible.com/ufz/zammad) when a Git tag that match the semantic version format is pushed.
Resolves #19 